### PR TITLE
IUS perma-links

### DIFF
--- a/magento-dbsetup-percona56-only
+++ b/magento-dbsetup-percona56-only
@@ -31,6 +31,20 @@ fi
 
 if [[ -e /etc/redhat-release ]]; then
   RELEASERPM=$(rpm -qf /etc/redhat-release)
+  case $RELEASERPM in
+    redhat*)
+      echo "detected RHEL"
+      OS=rhel
+      ;;
+    centos*)
+      echo "detected CentOS"
+      OS=centos
+      ;;
+    *)
+      echo "This script is for RHEL or CentOS only."
+      exit 1
+      ;;
+  esac
   MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
   case $MAJORVERS in
     6)

--- a/magento-dbsetup-percona56-only
+++ b/magento-dbsetup-percona56-only
@@ -29,12 +29,24 @@ fi
 
 
 
-MAJORVERS=$(head -1 /etc/redhat-release | cut -d"." -f1 | egrep -o '[0-9]')
-if [[ "$MAJORVERS"  == "6" ]] || [[ "$MAJORVERS"  == "7" ]]; then
-   echo "RHEL/CentOS $MAJORVERS Confirmed."
+if [[ -e /etc/redhat-release ]]; then
+  RELEASERPM=$(rpm -qf /etc/redhat-release)
+  MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
+  case $MAJORVERS in
+    6)
+      echo "detected major version 6"
+      ;;
+    7)
+      echo "detected major version 7"
+      ;;
+    *)
+      echo "This script is for major version 6 or 7 only."
+      exit 1
+      ;;
+  esac
 else
-   echo "This script is for RHEL/CentOS 6 or 7 only."
-   exit 1
+  echo "/etc/redhat-release not found"
+  exit 1
 fi
 
 

--- a/magento-dbsetup-percona56-only
+++ b/magento-dbsetup-percona56-only
@@ -100,9 +100,8 @@ else
       exit 1
   else
       # Cloud server - install IUS from repo
-      iusrelease=$(curl -s http://dl.iuscommunity.org/pub/ius/stable/CentOS/$MAJORVERS/x86_64/ | egrep -o 'href="ius-release.*rpm"' | cut -d'"' -f2)
       echo " - installing ius-release..."
-      yum -q -y install http://dl.iuscommunity.org/pub/ius/stable/CentOS/$MAJORVERS/x86_64/$iusrelease      
+      yum -q -y install https://$OS$MAJORVERS.iuscommunity.org/ius-release.rpm
       rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
   fi
 fi

--- a/magento-php-fpm.sh
+++ b/magento-php-fpm.sh
@@ -16,6 +16,20 @@ fi
 
 if [[ -e /etc/redhat-release ]]; then
   RELEASERPM=$(rpm -qf /etc/redhat-release)
+  case $RELEASERPM in
+    redhat*)
+      echo "detected RHEL"
+      OS=rhel
+      ;;
+    centos*)
+      echo "detected CentOS"
+      OS=centos
+      ;;
+    *)
+      echo "This script is for RHEL or CentOS only."
+      exit 1
+      ;;
+  esac
   MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
   case $MAJORVERS in
     6)

--- a/magento-php-fpm.sh
+++ b/magento-php-fpm.sh
@@ -95,9 +95,8 @@ else
       exit 1
   else
       # Cloud server - install IUS from repo
-      iusrelease=$(curl -s https://dl.iuscommunity.org/pub/ius/stable/CentOS/$MAJORVERS/x86_64/ | egrep -o 'href="ius-release.*rpm"' | cut -d'"' -f2)
       echo " - installing ius-release..."
-      yum -q -y install https://dl.iuscommunity.org/pub/ius/stable/CentOS/$MAJORVERS/x86_64/$iusrelease      
+      yum -q -y install https://$OS$MAJORVERS.iuscommunity.org/ius-release.rpm
       rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
   fi
 fi

--- a/magento-php-fpm.sh
+++ b/magento-php-fpm.sh
@@ -14,12 +14,24 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-MAJORVERS=$(head -1 /etc/redhat-release | cut -d"." -f1 | egrep -o '[0-9]')
-if [[ "$MAJORVERS"  == "6" ]] || [[ "$MAJORVERS"  == "7" ]]; then
-   echo "RHEL/CentOS $MAJORVERS Confirmed."
+if [[ -e /etc/redhat-release ]]; then
+  RELEASERPM=$(rpm -qf /etc/redhat-release)
+  MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
+  case $MAJORVERS in
+    6)
+      echo "detected major version 6"
+      ;;
+    7)
+      echo "detected major version 7"
+      ;;
+    *)
+      echo "This script is for major version 6 or 7 only."
+      exit 1
+      ;;
+  esac
 else
-   echo "This script is for RHEL/CentOS 6 or 7 only."
-   exit 1
+  echo "/etc/redhat-release not found"
+  exit 1
 fi
 
 

--- a/single-server-stack.sh
+++ b/single-server-stack.sh
@@ -12,12 +12,21 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-MAJORVERS=$(head -1 /etc/redhat-release | cut -d"." -f1 | egrep -o '[0-9]')
-if [[ "$MAJORVERS"  == "6" ]] || [[ "$MAJORVERS"  == "7" ]]; then
-   echo "RHEL/CentOS $MAJORVERS Confirmed."
+if [[ -e /etc/redhat-release ]]; then
+  RELEASERPM=$(rpm -qf /etc/redhat-release)
+  MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
+  case $MAJORVERS in
+    6)
+      echo "detected major version 6"
+      ;;
+    *)
+      echo "This script is for major version 6 only."
+      exit 1
+      ;;
+  esac
 else
-   echo "This script is for RHEL/CentOS 6 or 7 only."
-   exit 1
+  echo "/etc/redhat-release not found"
+  exit 1
 fi
 
 

--- a/single-server-stack.sh
+++ b/single-server-stack.sh
@@ -14,6 +14,20 @@ fi
 
 if [[ -e /etc/redhat-release ]]; then
   RELEASERPM=$(rpm -qf /etc/redhat-release)
+  case $RELEASERPM in
+    redhat*)
+      echo "detected RHEL"
+      OS=rhel
+      ;;
+    centos*)
+      echo "detected CentOS"
+      OS=centos
+      ;;
+    *)
+      echo "This script is for RHEL or CentOS only."
+      exit 1
+      ;;
+  esac
   MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
   case $MAJORVERS in
     6)

--- a/single-server-stack.sh
+++ b/single-server-stack.sh
@@ -90,9 +90,8 @@ else
       exit 1
   else
       # Cloud server - install IUS from repo
-      iusrelease=$(curl -s https://dl.iuscommunity.org/pub/ius/stable/CentOS/$MAJORVERS/x86_64/ | egrep -o 'href="ius-release.*rpm"' | cut -d'"' -f2)
       echo " - installing ius-release..."
-      yum -q -y install https://dl.iuscommunity.org/pub/ius/stable/CentOS/$MAJORVERS/x86_64/$iusrelease      
+      yum -q -y install https://$OS$MAJORVERS.iuscommunity.org/ius-release.rpm
       rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
   fi
 fi

--- a/web-stack.sh
+++ b/web-stack.sh
@@ -12,12 +12,22 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
-MAJORVERS=$(head -1 /etc/redhat-release | cut -d"." -f1 | egrep -o '[0-9]')
-if [ "$MAJORVERS"  != 6 ]; then
-   echo "This script is for CentOS 6 / RHEL 6  only."
-   exit 1
+if [[ -e /etc/redhat-release ]]; then
+  RELEASERPM=$(rpm -qf /etc/redhat-release)
+  MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
+  case $MAJORVERS in
+    6)
+      echo "detected major version 6"
+      ;;
+    *)
+      echo "This script is for major version 6 only."
+      exit 1
+      ;;
+  esac
+else
+  echo "/etc/redhat-release not found"
+  exit 1
 fi
-echo "RHEL/CentOS 6 Confirmed."
 
 
 ## Environment check - Cloud or Dedicated?

--- a/web-stack.sh
+++ b/web-stack.sh
@@ -14,6 +14,20 @@ fi
 
 if [[ -e /etc/redhat-release ]]; then
   RELEASERPM=$(rpm -qf /etc/redhat-release)
+  case $RELEASERPM in
+    redhat*)
+      echo "detected RHEL"
+      OS=rhel
+      ;;
+    centos*)
+      echo "detected CentOS"
+      OS=centos
+      ;;
+    *)
+      echo "This script is for RHEL or CentOS only."
+      exit 1
+      ;;
+  esac
   MAJORVERS=$(rpm -q --qf '%{VERSION}' $RELEASERPM)
   case $MAJORVERS in
     6)

--- a/web-stack.sh
+++ b/web-stack.sh
@@ -90,9 +90,8 @@ else
       exit 1
   else
       # Cloud server - install IUS from repo
-      iusrelease=$(curl -s http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ | grep ius-release | cut -d'"' -f8)
       echo " - installing ius-release..."
-      yum -q -y install http://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/$iusrelease      
+      yum -q -y install https://$OS$MAJORVERS.iuscommunity.org/ius-release.rpm
       rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
   fi
 fi


### PR DESCRIPTION
IUS now has redirect links that will stay valid even when the version or release of the ius-release package is incremented.  Those links are specific for RHEL/CentOS and major version, so I added some extra parsing logic to reliably determine that information.
